### PR TITLE
ti info implementation along with major Android and iOS related changes

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "3.13.2",
+  "lerna": "3.13.3",
   "version": "independent",
   "npmClient": "yarn",
   "packages": [

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "devDependencies": {
-    "lerna": "^3.13.2"
+    "lerna": "^3.13.3"
   },
   "scripts": {
     "build": "lerna exec gulp build",

--- a/packages/plugin-android/CHANGELOG.md
+++ b/packages/plugin-android/CHANGELOG.md
@@ -1,6 +1,11 @@
-# v1.4.0
+# v2.0.0
 
  * Updated config to remove redundant `android` namespace.
+ * Renamed 'sdk' and 'ndk' to 'sdks' and 'ndks'.
+ * No longer scan for 'android' executable.
+ * Removed 'targets'. Combine 'addons' and 'platforms' to get same result.
+ * Fixed bug with selecting the correct default Android SDK.
+ * Update dependencies.
 
 # v1.3.0 (Mar 29, 2019)
 

--- a/packages/plugin-android/package.json
+++ b/packages/plugin-android/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appcd/plugin-android",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "Android service for the Appc Daemon.",
   "main": "./dist/index",
   "author": "Appcelerator, Inc. <npmjs@appcelerator.com>",
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "androidlib": "^2.5.0",
-    "gawk": "^4.6.2",
+    "gawk": "^4.6.3",
     "semver": "^6.0.0",
-    "source-map-support": "^0.5.11"
+    "source-map-support": "^0.5.12"
   },
   "devDependencies": {
     "appcd-gulp": "^2.1.0",

--- a/packages/plugin-genymotion/CHANGELOG.md
+++ b/packages/plugin-genymotion/CHANGELOG.md
@@ -1,20 +1,21 @@
 # v1.4.0
 
  * Updated config to remove redundant `genymotion` namespace.
+ * Update dependencies.
 
 # v1.3.0 (Mar 29, 2019)
 
  * Upgraded to Gulp 4.
- * Update dependencies
+ * Update dependencies.
  * Fixed lint warnings.
  * Updated filesystem watching to use new `appcd.fs.watch()` and `appcd.fs.unwatch()` to optimize
    subscriptions. [(DAEMON-253)](https://jira.appcelerator.org/browse/DAEMON-253)
 
 # v1.2.0 (Oct 25, 2018)
 
- * Moved to `@appcd` scope
- * Update dependencies
- * Add Daemon 2.x support
+ * Moved to `@appcd` scope.
+ * Update dependencies.
+ * Add Daemon 2.x support.
 
 # v1.1.1 (Apr 13, 2018)
 

--- a/packages/plugin-genymotion/package.json
+++ b/packages/plugin-genymotion/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "androidlib": "^2.5.0",
-    "gawk": "^4.6.2",
-    "source-map-support": "^0.5.11",
+    "gawk": "^4.6.3",
+    "source-map-support": "^0.5.12",
     "xmldom": "^0.1.27"
   },
   "devDependencies": {

--- a/packages/plugin-ios/CHANGELOG.md
+++ b/packages/plugin-ios/CHANGELOG.md
@@ -1,20 +1,22 @@
-# v1.4.0
+# v2.0.0
 
  * Updated config to remove redundant `ios` namespace.
+ * Updated to latest ioslib which changes the iOS sim watch companion map.
+ * Update dependencies.
 
 # v1.3.0 (Mar 29, 2019)
 
  * Upgraded to Gulp 4.
- * Update dependencies
+ * Update dependencies.
  * Fixed lint warnings.
  * Updated filesystem watching to use new `appcd.fs.watch()` and `appcd.fs.unwatch()` to optimize
    subscriptions. [(DAEMON-253)](https://jira.appcelerator.org/browse/DAEMON-253)
 
 # v1.2.0 (Oct 25, 2018)
 
- * Moved to `@appcd` scope
- * Update dependencies
- * Add Daemon 2.x support
+ * Moved to `@appcd` scope.
+ * Update dependencies.
+ * Add Daemon 2.x support.
 
 # v1.1.1 (Aug 6, 2018)
 

--- a/packages/plugin-ios/package.json
+++ b/packages/plugin-ios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appcd/plugin-ios",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "iOS service for the Appc Daemon.",
   "main": "./dist/index",
   "author": "Appcelerator, Inc. <npmjs@appcelerator.com>",
@@ -16,10 +16,10 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "gawk": "^4.6.2",
+    "gawk": "^4.6.3",
     "ioslib": "^2.4.0",
     "semver": "^6.0.0",
-    "source-map-support": "^0.5.11"
+    "source-map-support": "^0.5.12"
   },
   "devDependencies": {
     "appcd-gulp": "^2.1.0",

--- a/packages/plugin-jdk/CHANGELOG.md
+++ b/packages/plugin-jdk/CHANGELOG.md
@@ -1,13 +1,17 @@
+# v1.3.1
+
+ * Update dependencies.
+
 # v1.3.0 (Mar 29, 2019)
 
  * Upgraded to Gulp 4.
- * Update dependencies
+ * Update dependencies.
 
 # v1.2.0 (Oct 25, 2018)
 
- * Moved to `@appcd` scope
- * Update dependencies
- * Add Daemon 2.x support
+ * Moved to `@appcd` scope.
+ * Update dependencies.
+ * Add Daemon 2.x support.
 
 # v1.1.0 (Apr 9, 2018)
 

--- a/packages/plugin-jdk/package.json
+++ b/packages/plugin-jdk/package.json
@@ -16,10 +16,10 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "gawk": "^4.6.2",
+    "gawk": "^4.6.3",
     "jdklib": "^2.4.0",
     "semver": "^6.0.0",
-    "source-map-support": "^0.5.11"
+    "source-map-support": "^0.5.12"
   },
   "devDependencies": {
     "appcd-gulp": "^2.1.0",

--- a/packages/plugin-system-info/CHANGELOG.md
+++ b/packages/plugin-system-info/CHANGELOG.md
@@ -1,7 +1,12 @@
+# v2.0.0
+
+ * Schema changes introduced by Android and iOS plugin schema changes.
+ * Update dependencies.
+
 # v1.3.0 (Mar 29, 2019)
 
  * Upgraded to Gulp 4.
- * Update dependencies
+ * Update dependencies.
  * Fixed lint warnings.
  * Refactored promises to use async/await.
  * Initialize the data destination before requesting data from an external plugin.
@@ -11,9 +16,9 @@
 
 # v1.2.0 (Oct 25, 2018)
 
- * Moved to `@appcd` scope
- * Update dependencies
- * Add Daemon 2.x support
+ * Moved to `@appcd` scope.
+ * Update dependencies.
+ * Add Daemon 2.x support.
 
 # v1.1.0 (Apr 11, 2018)
 

--- a/packages/plugin-system-info/package.json
+++ b/packages/plugin-system-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appcd/plugin-system-info",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "The Appc Daemon plugin for detecting system info.",
   "main": "./dist/index",
   "author": "Appcelerator, Inc. <npmjs@appcelerator.com>",
@@ -16,8 +16,8 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "gawk": "^4.6.2",
-    "source-map-support": "^0.5.11"
+    "gawk": "^4.6.3",
+    "source-map-support": "^0.5.12"
   },
   "devDependencies": {
     "appcd-gulp": "^2.1.0",

--- a/packages/plugin-system-info/src/index.js
+++ b/packages/plugin-system-info/src/index.js
@@ -19,9 +19,9 @@ import { isFile } from 'appcd-fs';
  * @type {Object}
  */
 const dependencies = {
-	android:            '/android/1.x/info',
+	android:            '/android/2.x/info',
 	genymotion:         '/genymotion/1.x/info',
-	ios:                '/ios/1.x/info',
+	ios:                '/ios/2.x/info',
 	jdks:               '/jdk/1.x/info',
 	'titanium/sdks':    '/titanium/1.x/sdk/list',
 	'titanium/modules': '/titanium/1.x/modules/list',

--- a/packages/plugin-titanium/CHANGELOG.md
+++ b/packages/plugin-titanium/CHANGELOG.md
@@ -5,6 +5,7 @@
  * Fixed version returned by `--version`.
  * Added appcd debug logger and plugin version to exec() data payload.
  * Added the `config` command implementation.
+ * Added the `info` command implementation.
  * Updated npm dependencies.
 
 # v1.4.0 (Mar 29, 2019)

--- a/packages/plugin-titanium/package.json
+++ b/packages/plugin-titanium/package.json
@@ -16,9 +16,13 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "cli-kit": "^0.10.0",
+    "chalk": "^2.4.2",
+    "cli-kit": "^0.10.2",
+    "dateformat": "^3.0.3",
+    "filesize": "^4.1.2",
     "fs-extra": "^7.0.1",
     "gawk": "^4.6.3",
+    "pluralize": "^7.0.0",
     "sort-object-keys": "^1.1.2",
     "source-map-support": "^0.5.12",
     "titaniumlib": "^1.2.0",

--- a/packages/plugin-titanium/src/cli/cli-service.js
+++ b/packages/plugin-titanium/src/cli/cli-service.js
@@ -87,7 +87,8 @@ export default class CLIService extends Dispatcher {
 				})
 			});
 
-			response.end();
+			stdout.end();
+			stderr.end();
 		});
 
 		this.register('/schema', ({ headers }) => this.cli.schema({

--- a/packages/plugin-titanium/src/cli/commands/info.js
+++ b/packages/plugin-titanium/src/cli/commands/info.js
@@ -7,42 +7,44 @@ import titanium from '../info/titanium';
 import windows from '../info/windows';
 
 const types = {
-	os,
-	titanium,
 	android,
 	genymotion,
 	ios,
 	jdk,
+	os,
+	titanium,
 	windows
 };
 
 export default {
-	async action({ console, argv }) {
-		console.log(argv);
-
-		const selectedTypes = argv.types === 'all' ? 'all' : argv.types.split(',');
+	async action({ console, argv, data }) {
+		const selectedTypes = new Set(argv.types.toLowerCase().split(','));
 		const results = {};
 
 		// load the data
 		await Promise.all(
 			Object
-				.entries(types)
-				.filter(([ type ]) => selectedTypes === 'all' || selectedTypes.includes(type))
-				.map(async ([ type, obj ]) => {
-					try {
-						results[type] = await obj.fetch(argv);
-					} catch (err) {
-						results[type] = err;
+				.keys(types)
+				.filter(type => typeof types[type].fetch === 'function' && (selectedTypes.has('all') || selectedTypes.has(type)))
+				.sort()
+				.map(async type => {
+					results[type] = null;
+					if (typeof types[type].fetch === 'function') {
+						try {
+							results[type] = await types[type].fetch(data);
+						} catch (err) {
+							results[type] = { error: err.stack };
+						}
 					}
 				})
 		);
 
-		if (argv.json) {
+		if (argv.json || argv.output === 'json') {
 			console.log(JSON.stringify(results, null, '  '));
 		} else {
 			// render
 			for (const type of Object.keys(results)) {
-				types[type].render(console, results[type]);
+				await types[type].render(console, results[type]);
 			}
 		}
 	},
@@ -58,7 +60,7 @@ export default {
 		'-t, --types <types>': {
 			default: 'all',
 			desc: 'information types to display; you may select one or more',
-			values: [ 'all' ].concat(Object.keys(types))
+			values: [ 'all', ...Object.keys(types).filter(type => typeof types[type].fetch === 'function') ]
 		}
 	}
 };

--- a/packages/plugin-titanium/src/cli/info/android.js
+++ b/packages/plugin-titanium/src/cli/info/android.js
@@ -1,9 +1,97 @@
 export default {
 	async fetch() {
-		return (await appcd.call('/android/1.x/info')).response;
+		return (await appcd.call('/android/2.x/info')).response;
 	},
 	render(console, info) {
-		console.log('Android');
-		console.log('hi from android info');
+		const chalk = require('chalk');
+		const { bold, cyan, gray, magenta } = chalk;
+
+		console.log(bold('Android SDKs'));
+		if (info.sdks.length) {
+			for (const sdk of info.sdks) {
+				console.log(`  ${cyan(sdk.path)}${sdk.default ? gray(' (default)') : ''}`);
+				console.log(`    ADB Executable      = ${magenta(sdk.platformTools.executables.adb || 'not installed')}`);
+				console.log(`    Build Tools         = ${magenta(sdk.buildTools.length ? sdk.buildTools.map(bt => bt.version).filter(v => v).join(', ') : 'not installed')}`);
+				console.log(`    Platform Tools      = ${magenta(sdk.platformTools.version || 'n/a')}`);
+				console.log(`    Tools               = ${magenta(sdk.tools.version || 'n/a')}`);
+				console.log('    Platforms:');
+				if (sdk.platforms.length) {
+					for (const platform of sdk.platforms) {
+						console.log(`      ${cyan(platform.sdk)}`);
+						console.log(`        Name            = ${magenta(platform.name)}`);
+						console.log(`        API Level       = ${magenta(platform.apiLevel)}`);
+						console.log(`        Revision        = ${magenta(platform.revision || '?')}`);
+						console.log(`        Path            = ${magenta(platform.path)}`);
+						console.log(`        Skins           = ${magenta(platform.skins.join(', '))}`);
+						console.log(`        Architectures   = ${magenta(Object.keys(platform.abis).map(name => `${name}: ${platform.abis[name].join(', ')}`))}`);
+					}
+				} else {
+					console.log(gray('      None'));
+				}
+				console.log('    Addons:');
+				if (sdk.addons.length) {
+					for (const addon of sdk.addons) {
+						console.log(`      ${cyan(addon.name)}`);
+						console.log(`        Name            = ${magenta(addon.name)}${addon.codename ? gray(` (${addon.codename})`) : ''}`);
+						console.log(`        API Level       = ${magenta(addon.apiLevel)}`);
+						console.log(`        Revision        = ${magenta(addon.revision || '?')}`);
+						console.log(`        Based On        = ${magenta(addon.basedOn ? `Android ${addon.basedOn.version}` : 'n/a')}`);
+						console.log(`        Path            = ${magenta(addon.path)}`);
+						console.log(`        Vendor          = ${magenta(addon.vendor)}`);
+						console.log(`        Description     = ${magenta(addon.description || 'n/a')}`);
+						console.log(`        Skins           = ${magenta(addon.skins && addon.skins.join(', ') || 'none')}`);
+						console.log(`        Architectures   = ${magenta(addon.abis && Object.keys(addon.abis).map(name => `${name}: ${addon.abis[name].join(', ')}`)) || 'none'}`);
+					}
+				} else {
+					console.log(gray('      None'));
+				}
+			}
+		} else {
+			console.log(gray('  None'));
+		}
+		console.log();
+
+		console.log(bold('Android NDKs'));
+		if (info.ndks.length) {
+			for (const ndk of info.ndks) {
+				console.log(`  ${cyan(ndk.path)}${ndk.default ? gray(' (default)') : ''}`);
+				console.log(`    Name                = ${magenta(ndk.name)}`);
+				console.log(`    Version             = ${magenta(ndk.version)}`);
+				console.log(`    Architecture        = ${magenta(ndk.arch)}`);
+				console.log(`    Path                = ${magenta(ndk.path)}`);
+			}
+		} else {
+			console.log(gray('  None'));
+		}
+		console.log();
+
+		console.log(bold('Android Emulators'));
+		if (info.emulators.length) {
+			for (const emu of info.emulators) {
+				console.log(`  ${cyan(emu.name)}${emu.type === 'avd' ? gray(' (AVD)') : emu.type === 'genymotion' ? gray(' (Genymotion)') : ''}`);
+				console.log(`    ID                  = ${magenta(emu.id)}`);
+				console.log(`    Version             = ${magenta(emu.target || '?')}`);
+				console.log(`    Architecture        = ${magenta(emu.abi)}`);
+				console.log(`    Path                = ${magenta(emu.path)}`);
+				console.log(`    Google APIs         = ${magenta(emu.googleApis === null ? 'Unknown' : emu.googleApis ? 'Yes' : 'No')}`);
+			}
+		} else {
+			console.log(gray('  None'));
+		}
+		console.log();
+
+		console.log(bold('Android Devices'));
+		if (info.devices.length) {
+			for (const device of info.devices) {
+				console.log(`  ${cyan(device.name)}${device.model ? gray(` (${device.model})`) : ''}`);
+				console.log(`    ID                  = ${magenta(device.id)}`);
+				console.log(`    State               = ${magenta(device.state)}`);
+				console.log(`    SDK Version         = ${magenta(`${device.release || '?'}${device.sdk ? ` (android-${device.sdk})` : ''}`)}`);
+				console.log(`    Architectures       = ${magenta(Array.isArray(device.abi) ? device.abi.sort().join(', ') : '?')}`);
+			}
+		} else {
+			console.log(gray('  None'));
+		}
+		console.log();
 	}
 };

--- a/packages/plugin-titanium/src/cli/info/genymotion.js
+++ b/packages/plugin-titanium/src/cli/info/genymotion.js
@@ -3,7 +3,40 @@ export default {
 		return (await appcd.call('/genymotion/1.x/info')).response;
 	},
 	render(console, info) {
-		console.log('Genymotion');
-		console.log('hi from genymotion info');
+		const chalk = require('chalk');
+		const { bold, cyan, gray, magenta } = chalk;
+
+		console.log(bold('Genymotion'));
+		if (info.path) {
+			console.log(`  App Path              = ${magenta(info.path)}`);
+			console.log(`  Genymotion Executable = ${magenta(info.executables.genymotion || 'not installed')}`);
+			console.log(`  Genymotion Player     = ${magenta(info.executables.player || 'not installed')}`);
+			console.log(`  Home                  = ${magenta(info.home)}`);
+			console.log('  Emulators:');
+			if (info.emulators.length) {
+				for (const emu of info.emulators) {
+					console.log(`    ${cyan(emu.name)}`);
+					console.log(`      ID                = ${magenta(emu.id)}`);
+					console.log(`      Version           = ${magenta(emu.target || '?')}`);
+					console.log(`      Architecture      = ${magenta(emu.abi)}`);
+					console.log(`      Path              = ${magenta(emu.path)}`);
+					console.log(`      Google APIs       = ${magenta(emu.googleApis === null ? 'Unknown' : emu.googleApis ? 'Yes' : 'No')}`);
+				}
+			} else {
+				console.log(gray('    None'));
+			}
+		} else {
+			console.log(gray('  Not installed'));
+		}
+		console.log();
+
+		console.log(bold('VirtualBox'));
+		if (info.virtualbox) {
+			console.log(`  Executable            = ${magenta(info.virtualbox.executables.vboxmanage)}`);
+			console.log(`  Version               = ${magenta(info.virtualbox.version)}`);
+		} else {
+			console.log(`  ${gray('Not installed')}`);
+		}
+		console.log();
 	}
 };

--- a/packages/plugin-titanium/src/cli/info/ios.js
+++ b/packages/plugin-titanium/src/cli/info/ios.js
@@ -1,7 +1,114 @@
 export default {
-	fetch: process.platform === 'darwin' && (async () => (await appcd.call('/ios/1.x/info')).response),
+	fetch: process.platform === 'darwin' && (async () => (await appcd.call('/ios/2.x/info')).response),
 	render(console, info) {
-		console.log('iOS');
-		console.log('hi from ios info');
+		const dateformat = require('dateformat');
+		const pluralize = require('pluralize');
+		const chalk = require('chalk');
+		const { bold, cyan, gray, magenta } = chalk;
+
+		console.log(bold('Xcode'));
+		if (info.xcode) {
+			for (const xcode of Object.values(info.xcode)) {
+				console.log(`  ${cyan(xcode.version)} (build ${xcode.build})${xcode.default ? gray(' (default)') : ''}}`);
+				console.log(`    App Path            = ${magenta(xcode.xcodeapp)}`);
+				console.log(`    iOS SDKs            = ${magenta(xcode.sdks.ios.join(', '))}`);
+				console.log(`    watchOS SDKs        = ${magenta(xcode.sdks.watchos.join(', '))}`);
+				console.log(`    EULA Accepted       = ${magenta(xcode.eulaAccepted ? 'Yes' : 'No')}`);
+			}
+		} else {
+			console.log(gray('  Not installed'));
+		}
+		console.log();
+
+		const pc = (title, certs) => {
+			console.log(`  ${cyan(title)}`);
+			certs = certs.filter(c => !c.invalid);
+			if (certs.length) {
+				for (const cert of certs) {
+					console.log(`    ${cert.name}`);
+					console.log(`      Not valid before  = ${magenta(cert.before ?  dateformat(cert.before, 'm/d/yyyy h:MM TT') : 'unknown')}`);
+					if (cert.after) {
+						const days = Math.floor((new Date(cert.after) - new Date()) / 1000 / 60 / 60 / 24);
+						console.log(`      Not valid after   = ${magenta(dateformat(cert.after, 'm/d/yyyy h:MM TT'))} ${gray(`(expires in ${pluralize('day', days, true)})`)}`);
+					} else {
+						console.log(`      Not valid after   = ${magenta('unknown')}`);
+					}
+				}
+			} else {
+				console.log(gray('    None'));
+			}
+		};
+		console.log(bold('Certificates'));
+		console.log(cyan('  Apple WWDR Cert'));
+		if (!info.certs.wwdr) {
+			console.log('    Installed');
+		} else {
+			console.log(`    Not installed, visit ${magenta('https://developer.apple.com/support/certificates/expiration/')}`);
+		}
+
+		pc('Development', info.certs.developer);
+		pc('Distribution', info.certs.distribution);
+		console.log();
+
+		const pp = (title, profiles) => {
+			console.log(`  ${cyan(title)}`);
+			profiles = profiles.filter(p => !p.expired && !p.managed);
+			if (profiles.length) {
+				for (const p of profiles) {
+					console.log(`    ${p.name}`);
+					console.log(`      UUID              = ${magenta(p.uuid)}`);
+					console.log(`      App ID            = ${magenta(p.entitlements['application-identifier'] || '?')}`);
+					console.log(`      Date Created      = ${magenta(p.creationDate ?  dateformat(p.creationDate, 'm/d/yyyy h:MM TT') : 'unknown')}`);
+					if (p.expirationDate) {
+						const days = Math.floor((new Date(p.expirationDate) - new Date()) / 1000 / 60 / 60 / 24);
+						console.log(`      Date Expires      = ${magenta(dateformat(p.expirationDate, 'm/d/yyyy h:MM TT'))} ${gray(`(expires in ${pluralize('day', days, true)})`)}`);
+					} else {
+						console.log(`      Date Expires      = ${magenta('unknown')}`);
+					}
+				}
+			} else {
+				console.log(gray('    None'));
+			}
+		};
+		console.log(bold('Provisioning Profiles'));
+		pp('Development',                    info.provisioning.development);
+		pp('App Store Distribution',         info.provisioning.distribution);
+		pp('Ad Hoc Distribution',            info.provisioning.adhoc);
+		pp('Enterprice Ad Hoc Distribution', info.provisioning.enterprise);
+		console.log();
+
+		const ps = (title, data) => {
+			const vers = Object.keys(data);
+			if (vers.length) {
+				for (const ver of vers) {
+					console.log(cyan(`  ${title} ${ver}`));
+					const sims = data[ver];
+					for (const sim of sims) {
+						const supportsWatch = sim.supportsWatch && Object.values(sim.supportsWatch).filter(x => x).length;
+						console.log(`   ${supportsWatch ? gray('*') : ' '}${sim.name.substring(0, 36).padEnd(36)} = ${magenta(sim.udid)}`);
+					}
+				}
+			} else {
+				console.log(gray('    None'));
+			}
+		};
+		console.log(`${bold('Simulators')} ${gray('(*supports watch sim pairing)')}`);
+		ps('iOS', info.simulators.ios);
+		ps('watchOS', info.simulators.watchos);
+		console.log();
+
+		console.log(bold('iOS Devices'));
+		if (info.devices.length) {
+			for (const device of info.devices) {
+				console.log(`  ${cyan(device.name)}`);
+				console.log(`    UDID                = ${magenta(device.udid)}`);
+				console.log(`    Type                = ${magenta(`${device.deviceClass} (${device.deviceColor})`)}`);
+				console.log(`    iOS Version         = ${magenta(device.productVersion)}`);
+				console.log(`    CPU Architecture    = ${magenta(device.cpuArchitecture)}`);
+			}
+		} else {
+			console.log(gray('  None'));
+		}
+		console.log();
 	}
 };

--- a/packages/plugin-titanium/src/cli/info/jdk.js
+++ b/packages/plugin-titanium/src/cli/info/jdk.js
@@ -3,7 +3,19 @@ export default {
 		return (await appcd.call('/jdk/1.x/info')).response;
 	},
 	render(console, info) {
-		console.log('Java Development Kit');
-		console.log('hi from jdk info');
+		const chalk = require('chalk');
+		const { bold, cyan, gray, magenta } = chalk;
+
+		console.log(bold('Java Development Kit'));
+		if (info.length) {
+			for (const jdk of info) {
+				console.log(`  ${cyan(`${jdk.version}:${jdk.build}`)}${jdk.default ? gray(' (default)') : ''}`);
+				console.log(`    Architecture        = ${magenta(jdk.arch)}`);
+				console.log(`    Path                = ${magenta(jdk.path)}`);
+			}
+		} else {
+			console.log(gray('  Not installed'));
+		}
+		console.log();
 	}
 };

--- a/packages/plugin-titanium/src/cli/info/os.js
+++ b/packages/plugin-titanium/src/cli/info/os.js
@@ -74,7 +74,16 @@ export default {
 	},
 
 	render(console, info) {
-		console.log('Operating System');
-		console.log(JSON.stringify(info));
+		const chalk = require('chalk');
+		const filesize = require('filesize');
+		const { bold, magenta } = chalk;
+
+		console.log(bold('Operating System'));
+		console.log(`  Name                  = ${magenta(info.name)}`);
+		console.log(`  Version               = ${magenta(info.version)}`);
+		console.log(`  Architecture          = ${magenta(info.arch === 'x64' ? '64-bit' : '32-bit')}`);
+		console.log(`  # CPUs                = ${magenta(info.numcpus)}`);
+		console.log(`  Memory                = ${magenta(filesize(info.memory))}`);
+		console.log();
 	}
 };

--- a/packages/plugin-titanium/src/cli/info/titanium.js
+++ b/packages/plugin-titanium/src/cli/info/titanium.js
@@ -9,14 +9,30 @@ export default {
 			plugin: {
 				version: data.pluginVersion
 			},
-			sdks: (await appcd.call('/sdks')).response
+			sdks: (await appcd.call('/sdk')).response
 		};
 	},
 	render(console, info) {
-		console.log('Titanium CLI');
-		console.log('hi from titanium cli info');
+		const chalk = require('chalk');
+		const { bold, cyan, gray, magenta } = chalk;
 
-		console.log('Titanium SDK');
-		console.log('hi from titanium sdk info');
+		console.log(bold('Titanium CLI'));
+		console.log(`  CLI Version           = ${magenta(info.cli.version)}`);
+		console.log(`  Plugin Version        = ${magenta(info.plugin.version)}`);
+		console.log();
+
+		console.log(bold('Titanium SDK'));
+		if (info.sdks.length) {
+			for (const sdk of info.sdks) {
+				console.log(`  ${cyan(sdk.name)}`);
+				console.log(`    Version             = ${magenta(sdk.manifest.version)}`);
+				console.log(`    Install Location    = ${magenta(sdk.path)}`);
+				console.log(`    Platforms           = ${magenta(sdk.manifest.platforms.sort().join(', '))}`);
+				console.log(`    git Hash            = ${magenta(sdk.manifest.githash || 'unknown')}`);
+			}
+		} else {
+			console.log(gray('  None'));
+		}
+		console.log();
 	}
 };

--- a/packages/plugin-titanium/src/cli/info/windows.js
+++ b/packages/plugin-titanium/src/cli/info/windows.js
@@ -1,7 +1,11 @@
 export default {
 	fetch: process.platform === 'win32' && (async () => (await appcd.call('/windows/1.x/info')).response),
 	render(console, info) {
+		const chalk = require('chalk');
+		const { bold, cyan, gray, magenta } = chalk;
+
 		console.log('Windows');
-		console.log('hi from windows info');
+		console.log(info);
+		console.log();
 	}
 };

--- a/packages/plugin-windows/CHANGELOG.md
+++ b/packages/plugin-windows/CHANGELOG.md
@@ -1,11 +1,12 @@
 # v1.4.0
 
  * Updated config to remove redundant `windows` namespace.
+ * Update dependencies.
 
 # v1.3.0 (Mar 29, 2019)
 
  * Upgraded to Gulp 4.
- * Update dependencies
+ * Update dependencies.
  * Refactored promises to use async/await.
 
 # v1.2.0 (Oct 25, 2018)

--- a/packages/plugin-windows/package.json
+++ b/packages/plugin-windows/package.json
@@ -16,8 +16,8 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "gawk": "^4.6.2",
-    "source-map-support": "^0.5.11",
+    "gawk": "^4.6.3",
+    "source-map-support": "^0.5.12",
     "windowslib": "^0.6.8"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -327,14 +327,14 @@
     normalize-path "^2.0.1"
     through2 "^2.0.3"
 
-"@lerna/add@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.13.1.tgz#2cd7838857edb3b43ed73e3c21f69a20beb9b702"
-  integrity sha512-cXk42YbuhzEnADCK8Qte5laC9Qo03eJLVnr0qKY85jQUM/T4URe3IIUemqpg0CpVATrB+Vz+iNdeqw9ng1iALw==
+"@lerna/add@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.13.3.tgz#f4c1674839780e458f0426d4f7b6d0a77b9a2ae9"
+  integrity sha512-T3/Lsbo9ZFq+vL3ssaHxA8oKikZAPTJTGFe4CRuQgWCDd/M61+51jeWsngdaHpwzSSRDRjxg8fJTG10y10pnfA==
   dependencies:
-    "@lerna/bootstrap" "3.13.1"
-    "@lerna/command" "3.13.1"
-    "@lerna/filter-options" "3.13.0"
+    "@lerna/bootstrap" "3.13.3"
+    "@lerna/command" "3.13.3"
+    "@lerna/filter-options" "3.13.3"
     "@lerna/npm-conf" "3.13.0"
     "@lerna/validation-error" "3.13.0"
     dedent "^0.7.0"
@@ -352,19 +352,19 @@
     "@lerna/validation-error" "3.13.0"
     npmlog "^4.1.2"
 
-"@lerna/bootstrap@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/bootstrap/-/bootstrap-3.13.1.tgz#f2edd7c8093c8b139e78b0ca5f845f23efd01f08"
-  integrity sha512-mKdi5Ds5f82PZwEFyB9/W60I3iELobi1i87sTeVrbJh/um7GvqpSPy7kG/JPxyOdMpB2njX6LiJgw+7b6BEPWw==
+"@lerna/bootstrap@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/bootstrap/-/bootstrap-3.13.3.tgz#a0e5e466de5c100b49d558d39139204fc4db5c95"
+  integrity sha512-2XzijnLHRZOVQh8pwS7+5GR3cG4uh+EiLrWOishCq2TVzkqgjaS3GGBoef7KMCXfWHoLqAZRr/jEdLqfETLVqg==
   dependencies:
     "@lerna/batch-packages" "3.13.0"
-    "@lerna/command" "3.13.1"
-    "@lerna/filter-options" "3.13.0"
-    "@lerna/has-npm-version" "3.13.0"
-    "@lerna/npm-install" "3.13.0"
+    "@lerna/command" "3.13.3"
+    "@lerna/filter-options" "3.13.3"
+    "@lerna/has-npm-version" "3.13.3"
+    "@lerna/npm-install" "3.13.3"
     "@lerna/package-graph" "3.13.0"
     "@lerna/pulse-till-done" "3.13.0"
-    "@lerna/rimraf-dir" "3.13.0"
+    "@lerna/rimraf-dir" "3.13.3"
     "@lerna/run-lifecycle" "3.13.0"
     "@lerna/run-parallel-batches" "3.13.0"
     "@lerna/symlink-binary" "3.13.0"
@@ -382,44 +382,44 @@
     read-package-tree "^5.1.6"
     semver "^5.5.0"
 
-"@lerna/changed@3.13.2":
-  version "3.13.2"
-  resolved "https://registry.yarnpkg.com/@lerna/changed/-/changed-3.13.2.tgz#2eda47d3e6c20a0f84c379a9e6806e59eeeaad79"
-  integrity sha512-mcmkxUMR0J4ZyRyVUrdDJl4ZsdHDgdA1xQcbdB4LZvAE/E2lNlPcEfAfbfs08VnRiqvFOqcczbzBq10hvSFg4w==
+"@lerna/changed@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/changed/-/changed-3.13.3.tgz#f2a2e982f4317157345f7abb3f6b12cc69394657"
+  integrity sha512-REMZ/1UvYrizUhN7ktlbfMUa0vhMf1ogAe97WQC4I8r3s973Orfhs3aselo1GwudUwM4tMHBH8A9vnll9or3iA==
   dependencies:
-    "@lerna/collect-updates" "3.13.0"
-    "@lerna/command" "3.13.1"
+    "@lerna/collect-updates" "3.13.3"
+    "@lerna/command" "3.13.3"
     "@lerna/listable" "3.13.0"
     "@lerna/output" "3.13.0"
-    "@lerna/version" "3.13.2"
+    "@lerna/version" "3.13.3"
 
-"@lerna/check-working-tree@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/check-working-tree/-/check-working-tree-3.13.0.tgz#1ddcd4d9b1aceb65efaaa4cd1333a66706d67c9c"
-  integrity sha512-dsdO15NXX5To+Q53SYeCrBEpiqv4m5VkaPZxbGQZNwoRen1MloXuqxSymJANQn+ZLEqarv5V56gydebeROPH5A==
+"@lerna/check-working-tree@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/check-working-tree/-/check-working-tree-3.13.3.tgz#836a3ffd4413a29aca92ccca4a115e4f97109992"
+  integrity sha512-LoGZvTkne+V1WpVdCTU0XNzFKsQa2AiAFKksGRT0v8NQj6VAPp0jfVYDayTqwaWt2Ne0OGKOFE79Y5LStOuhaQ==
   dependencies:
-    "@lerna/describe-ref" "3.13.0"
+    "@lerna/describe-ref" "3.13.3"
     "@lerna/validation-error" "3.13.0"
 
-"@lerna/child-process@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/child-process/-/child-process-3.13.0.tgz#84e35adf3217a6983edd28080657b9596a052674"
-  integrity sha512-0iDS8y2jiEucD4fJHEzKoc8aQJgm7s+hG+0RmDNtfT0MM3n17pZnf5JOMtS1FJp+SEXOjMKQndyyaDIPFsnp6A==
+"@lerna/child-process@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/child-process/-/child-process-3.13.3.tgz#6c084ee5cca9fc9e04d6bf4fc3f743ed26ff190c"
+  integrity sha512-3/e2uCLnbU+bydDnDwyadpOmuzazS01EcnOleAnuj9235CU2U97DH6OyoG1EW/fU59x11J+HjIqovh5vBaMQjQ==
   dependencies:
     chalk "^2.3.1"
     execa "^1.0.0"
     strong-log-transformer "^2.0.0"
 
-"@lerna/clean@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/clean/-/clean-3.13.1.tgz#9a7432efceccd720a51da5c76f849fc59c5a14ce"
-  integrity sha512-myGIaXv7RUO2qCFZXvx8SJeI+eN6y9SUD5zZ4/LvNogbOiEIlujC5lUAqK65rAHayQ9ltSa/yK6Xv510xhZXZQ==
+"@lerna/clean@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/clean/-/clean-3.13.3.tgz#5673a1238e0712d31711e7e4e8cb9641891daaea"
+  integrity sha512-xmNauF1PpmDaKdtA2yuRc23Tru4q7UMO6yB1a/TTwxYPYYsAWG/CBK65bV26J7x4RlZtEv06ztYGMa9zh34UXA==
   dependencies:
-    "@lerna/command" "3.13.1"
-    "@lerna/filter-options" "3.13.0"
+    "@lerna/command" "3.13.3"
+    "@lerna/filter-options" "3.13.3"
     "@lerna/prompt" "3.13.0"
     "@lerna/pulse-till-done" "3.13.0"
-    "@lerna/rimraf-dir" "3.13.0"
+    "@lerna/rimraf-dir" "3.13.3"
     p-map "^1.2.0"
     p-map-series "^1.0.0"
     p-waterfall "^1.0.0"
@@ -434,23 +434,23 @@
     npmlog "^4.1.2"
     yargs "^12.0.1"
 
-"@lerna/collect-updates@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/collect-updates/-/collect-updates-3.13.0.tgz#f0828d84ff959ff153d006765659ffc4d68cdefc"
-  integrity sha512-uR3u6uTzrS1p46tHQ/mlHog/nRJGBqskTHYYJbgirujxm6FqNh7Do+I1Q/7zSee407G4lzsNxZdm8IL927HemQ==
+"@lerna/collect-updates@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/collect-updates/-/collect-updates-3.13.3.tgz#616648da59f0aff4a8e60257795cc46ca6921edd"
+  integrity sha512-sTpALOAxli/ZS+Mjq6fbmjU9YXqFJ2E4FrE1Ijl4wPC5stXEosg2u0Z1uPY+zVKdM+mOIhLxPVdx83rUgRS+Cg==
   dependencies:
-    "@lerna/child-process" "3.13.0"
-    "@lerna/describe-ref" "3.13.0"
+    "@lerna/child-process" "3.13.3"
+    "@lerna/describe-ref" "3.13.3"
     minimatch "^3.0.4"
     npmlog "^4.1.2"
     slash "^1.0.0"
 
-"@lerna/command@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/command/-/command-3.13.1.tgz#b60dda2c0d9ffbb6030d61ddf7cceedc1e8f7e6e"
-  integrity sha512-SYWezxX+iheWvzRoHCrbs8v5zHPaxAx3kWvZhqi70vuGsdOVAWmaG4IvHLn11ztS+Vpd5PM+ztBWSbnykpLFKQ==
+"@lerna/command@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/command/-/command-3.13.3.tgz#5b20b3f507224573551039e0460bc36c39f7e9d1"
+  integrity sha512-WHFIQCubJV0T8gSLRNr6exZUxTswrh+iAtJCb86SE0Sa+auMPklE8af7w2Yck5GJfewmxSjke3yrjNxQrstx7w==
   dependencies:
-    "@lerna/child-process" "3.13.0"
+    "@lerna/child-process" "3.13.3"
     "@lerna/package-graph" "3.13.0"
     "@lerna/project" "3.13.1"
     "@lerna/validation-error" "3.13.0"
@@ -486,13 +486,13 @@
     fs-extra "^7.0.0"
     npmlog "^4.1.2"
 
-"@lerna/create@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/create/-/create-3.13.1.tgz#2c1284cfdc59f0d2b88286d78bc797f4ab330f79"
-  integrity sha512-pLENMXgTkQuvKxAopjKeoLOv9fVUCnpTUD7aLrY5d95/1xqSZlnsOcQfUYcpMf3GpOvHc8ILmI5OXkPqjAf54g==
+"@lerna/create@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/create/-/create-3.13.3.tgz#6ded142c54b7f3cea86413c3637b067027b7f55d"
+  integrity sha512-4M5xT1AyUMwt1gCDph4BfW3e6fZmt0KjTa3FoXkUotf/w/eqTsc2IQ+ULz2+gOFQmtuNbqIZEOK3J4P9ArJJ/A==
   dependencies:
-    "@lerna/child-process" "3.13.0"
-    "@lerna/command" "3.13.1"
+    "@lerna/child-process" "3.13.3"
+    "@lerna/command" "3.13.3"
     "@lerna/npm-conf" "3.13.0"
     "@lerna/validation-error" "3.13.0"
     camelcase "^5.0.0"
@@ -510,42 +510,42 @@
     validate-npm-package-name "^3.0.0"
     whatwg-url "^7.0.0"
 
-"@lerna/describe-ref@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/describe-ref/-/describe-ref-3.13.0.tgz#fb4c3863fd6bcccad67ce7b183887a5fc1942bb6"
-  integrity sha512-UJefF5mLxLae9I2Sbz5RLYGbqbikRuMqdgTam0MS5OhXnyuuKYBUpwBshCURNb1dPBXTQhSwc7+oUhORx8ojCg==
+"@lerna/describe-ref@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/describe-ref/-/describe-ref-3.13.3.tgz#13318513613f6a407d37fc5dc025ec2cfb705606"
+  integrity sha512-5KcLTvjdS4gU5evW8ESbZ0BF44NM5HrP3dQNtWnOUSKJRgsES8Gj0lq9AlB2+YglZfjEftFT03uOYOxnKto4Uw==
   dependencies:
-    "@lerna/child-process" "3.13.0"
+    "@lerna/child-process" "3.13.3"
     npmlog "^4.1.2"
 
-"@lerna/diff@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/diff/-/diff-3.13.1.tgz#5c734321b0f6c46a3c87f55c99afef3b01d46520"
-  integrity sha512-cKqmpONO57mdvxtp8e+l5+tjtmF04+7E+O0QEcLcNUAjC6UR2OSM77nwRCXDukou/1h72JtWs0jjcdYLwAmApg==
+"@lerna/diff@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/diff/-/diff-3.13.3.tgz#883cb3a83a956dbfc2c17bc9a156468a5d3fae17"
+  integrity sha512-/DRS2keYbnKaAC+5AkDyZRGkP/kT7v1GlUS0JGZeiRDPQ1H6PzhX09EgE5X6nj0Ytrm0sUasDeN++CDVvgaI+A==
   dependencies:
-    "@lerna/child-process" "3.13.0"
-    "@lerna/command" "3.13.1"
+    "@lerna/child-process" "3.13.3"
+    "@lerna/command" "3.13.3"
     "@lerna/validation-error" "3.13.0"
     npmlog "^4.1.2"
 
-"@lerna/exec@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/exec/-/exec-3.13.1.tgz#4439e90fb0877ec38a6ef933c86580d43eeaf81b"
-  integrity sha512-I34wEP9lrAqqM7tTXLDxv/6454WFzrnXDWpNDbiKQiZs6SIrOOjmm6I4FiQsx+rU3o9d+HkC6tcUJRN5mlJUgA==
+"@lerna/exec@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/exec/-/exec-3.13.3.tgz#5d2eda3f6e584f2f15b115e8a4b5bc960ba5de85"
+  integrity sha512-c0bD4XqM96CTPV8+lvkxzE7mkxiFyv/WNM4H01YvvbFAJzk+S4Y7cBtRkIYFTfkFZW3FLo8pEgtG1ONtIdM+tg==
   dependencies:
     "@lerna/batch-packages" "3.13.0"
-    "@lerna/child-process" "3.13.0"
-    "@lerna/command" "3.13.1"
-    "@lerna/filter-options" "3.13.0"
+    "@lerna/child-process" "3.13.3"
+    "@lerna/command" "3.13.3"
+    "@lerna/filter-options" "3.13.3"
     "@lerna/run-parallel-batches" "3.13.0"
     "@lerna/validation-error" "3.13.0"
 
-"@lerna/filter-options@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/filter-options/-/filter-options-3.13.0.tgz#976e3d8b9fcd47001ab981d276565c1e9f767868"
-  integrity sha512-SRp7DCo9zrf+7NkQxZMkeyO1GRN6GICoB9UcBAbXhLbWisT37Cx5/6+jh49gYB63d/0/WYHSEPMlheUrpv1Srw==
+"@lerna/filter-options@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/filter-options/-/filter-options-3.13.3.tgz#aa42a4ab78837b8a6c4278ba871d27e92d77c54f"
+  integrity sha512-DbtQX4eRgrBz1wCFWRP99JBD7ODykYme9ykEK79+RrKph40znhJQRlLg4idogj6IsUEzwo1OHjihCzSfnVo6Cg==
   dependencies:
-    "@lerna/collect-updates" "3.13.0"
+    "@lerna/collect-updates" "3.13.3"
     "@lerna/filter-packages" "3.13.0"
     dedent "^0.7.0"
 
@@ -574,12 +574,12 @@
     ssri "^6.0.1"
     tar "^4.4.8"
 
-"@lerna/github-client@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/github-client/-/github-client-3.13.1.tgz#cb9bf9f01685a0cee0fac63f287f6c3673e45aa3"
-  integrity sha512-iPLUp8FFoAKGURksYEYZzfuo9TRA+NepVlseRXFaWlmy36dCQN20AciINpoXiXGoHcEUHXUKHQvY3ARFdMlf3w==
+"@lerna/github-client@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/github-client/-/github-client-3.13.3.tgz#bcf9b4ff40bdd104cb40cd257322f052b41bb9ce"
+  integrity sha512-fcJkjab4kX0zcLLSa/DCUNvU3v8wmy2c1lhdIbL7s7gABmDcV0QZq93LhnEee3VkC9UpnJ6GKG4EkD7eIifBnA==
   dependencies:
-    "@lerna/child-process" "3.13.0"
+    "@lerna/child-process" "3.13.3"
     "@octokit/plugin-enterprise-rest" "^2.1.1"
     "@octokit/rest" "^16.16.0"
     git-url-parse "^11.1.2"
@@ -590,21 +590,21 @@
   resolved "https://registry.yarnpkg.com/@lerna/global-options/-/global-options-3.13.0.tgz#217662290db06ad9cf2c49d8e3100ee28eaebae1"
   integrity sha512-SlZvh1gVRRzYLVluz9fryY1nJpZ0FHDGB66U9tFfvnnxmueckRQxLopn3tXj3NU1kc3QANT2I5BsQkOqZ4TEFQ==
 
-"@lerna/has-npm-version@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/has-npm-version/-/has-npm-version-3.13.0.tgz#6e1f7e9336cce3e029066f0175f06dd9d51ad09f"
-  integrity sha512-Oqu7DGLnrMENPm+bPFGOHnqxK8lCnuYr6bk3g/CoNn8/U0qgFvHcq6Iv8/Z04TsvleX+3/RgauSD2kMfRmbypg==
+"@lerna/has-npm-version@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/has-npm-version/-/has-npm-version-3.13.3.tgz#167e3f602a2fb58f84f93cf5df39705ca6432a2d"
+  integrity sha512-mQzoghRw4dBg0R9FFfHrj0TH0glvXyzdEZmYZ8Isvx5BSuEEwpsryoywuZSdppcvLu8o7NAdU5Tac8cJ/mT52w==
   dependencies:
-    "@lerna/child-process" "3.13.0"
+    "@lerna/child-process" "3.13.3"
     semver "^5.5.0"
 
-"@lerna/import@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/import/-/import-3.13.1.tgz#69d641341a38b79bd379129da1c717d51dd728c7"
-  integrity sha512-A1Vk1siYx1XkRl6w+zkaA0iptV5TIynVlHPR9S7NY0XAfhykjztYVvwtxarlh6+VcNrO9We6if0+FXCrfDEoIg==
+"@lerna/import@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/import/-/import-3.13.3.tgz#1dc84f2c5644ba874be9552395a3b158688b263c"
+  integrity sha512-gDjLAFVavG/CMvj9leBfiwd7vrXqtdFXPIz1oXmghBMnje7nCTbodbNWFe4VDDWx7reDaZIN+6PxTSvrPcF//A==
   dependencies:
-    "@lerna/child-process" "3.13.0"
-    "@lerna/command" "3.13.1"
+    "@lerna/child-process" "3.13.3"
+    "@lerna/command" "3.13.3"
     "@lerna/prompt" "3.13.0"
     "@lerna/pulse-till-done" "3.13.0"
     "@lerna/validation-error" "3.13.0"
@@ -612,35 +612,35 @@
     fs-extra "^7.0.0"
     p-map-series "^1.0.0"
 
-"@lerna/init@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/init/-/init-3.13.1.tgz#0392c822abb3d63a75be4916c5e761cfa7b34dda"
-  integrity sha512-M59WACqim8WkH5FQEGOCEZ89NDxCKBfFTx4ZD5ig3LkGyJ8RdcJq5KEfpW/aESuRE9JrZLzVr0IjKbZSxzwEMA==
+"@lerna/init@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/init/-/init-3.13.3.tgz#ebd522fee9b9d7d3b2dacb0261eaddb4826851ff"
+  integrity sha512-bK/mp0sF6jT0N+c+xrbMCqN4xRoiZCXQzlYsyACxPK99KH/mpHv7hViZlTYUGlYcymtew6ZC770miv5A9wF9hA==
   dependencies:
-    "@lerna/child-process" "3.13.0"
-    "@lerna/command" "3.13.1"
+    "@lerna/child-process" "3.13.3"
+    "@lerna/command" "3.13.3"
     fs-extra "^7.0.0"
     p-map "^1.2.0"
     write-json-file "^2.3.0"
 
-"@lerna/link@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/link/-/link-3.13.1.tgz#7d8ed4774bfa198d1780f790a14abb8722a3aad1"
-  integrity sha512-N3h3Fj1dcea+1RaAoAdy4g2m3fvU7m89HoUn5X/Zcw5n2kPoK8kTO+NfhNAatfRV8VtMXst8vbNrWQQtfm0FFw==
+"@lerna/link@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/link/-/link-3.13.3.tgz#11124d4a0c8d0b79752fbda3babedfd62dd57847"
+  integrity sha512-IHhtdhA0KlIdevCsq6WHkI2rF3lHWHziJs2mlrEWAKniVrFczbELON1KJAgdJS1k3kAP/WeWVqmIYZ2hJDxMvg==
   dependencies:
-    "@lerna/command" "3.13.1"
+    "@lerna/command" "3.13.3"
     "@lerna/package-graph" "3.13.0"
     "@lerna/symlink-dependencies" "3.13.0"
     p-map "^1.2.0"
     slash "^1.0.0"
 
-"@lerna/list@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/list/-/list-3.13.1.tgz#f9513ed143e52156c10ada4070f903c5847dcd10"
-  integrity sha512-635iRbdgd9gNvYLLIbYdQCQLr+HioM5FGJLFS0g3DPGygr6iDR8KS47hzCRGH91LU9NcM1mD1RoT/AChF+QbiA==
+"@lerna/list@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/list/-/list-3.13.3.tgz#fa93864d43cadeb4cd540a4e78a52886c57dbe74"
+  integrity sha512-rLRDsBCkydMq2FL6WY1J/elvnXIjxxRtb72lfKHdvDEqVdquT5Qgt9ci42hwjmcocFwWcFJgF6BZozj5pbc13A==
   dependencies:
-    "@lerna/command" "3.13.1"
-    "@lerna/filter-options" "3.13.0"
+    "@lerna/command" "3.13.3"
+    "@lerna/filter-options" "3.13.3"
     "@lerna/listable" "3.13.0"
     "@lerna/output" "3.13.0"
 
@@ -681,12 +681,12 @@
     npm-registry-fetch "^3.9.0"
     npmlog "^4.1.2"
 
-"@lerna/npm-install@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/npm-install/-/npm-install-3.13.0.tgz#88f4cc39f4f737c8a8721256b915ea1bcc6a7227"
-  integrity sha512-qNyfts//isYQxore6fsPorNYJmPVKZ6tOThSH97tP0aV91zGMtrYRqlAoUnDwDdAjHPYEM16hNujg2wRmsqqIw==
+"@lerna/npm-install@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/npm-install/-/npm-install-3.13.3.tgz#9b09852732e51c16d2e060ff2fd8bfbbb49cf7ba"
+  integrity sha512-7Jig9MLpwAfcsdQ5UeanAjndChUjiTjTp50zJ+UZz4CbIBIDhoBehvNMTCL2G6pOEC7sGEg6sAqJINAqred6Tg==
   dependencies:
-    "@lerna/child-process" "3.13.0"
+    "@lerna/child-process" "3.13.3"
     "@lerna/get-npm-exec-opts" "3.13.0"
     fs-extra "^7.0.0"
     npm-package-arg "^6.1.0"
@@ -708,12 +708,12 @@
     pify "^3.0.0"
     read-package-json "^2.0.13"
 
-"@lerna/npm-run-script@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/npm-run-script/-/npm-run-script-3.13.0.tgz#e5997f045402b9948bdc066033ebb36bf94fc9e4"
-  integrity sha512-hiL3/VeVp+NFatBjkGN8mUdX24EfZx9rQlSie0CMgtjc7iZrtd0jCguLomSCRHYjJuvqgbp+LLYo7nHVykfkaQ==
+"@lerna/npm-run-script@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/npm-run-script/-/npm-run-script-3.13.3.tgz#9bb6389ed70cd506905d6b05b6eab336b4266caf"
+  integrity sha512-qR4o9BFt5hI8Od5/DqLalOJydnKpiQFEeN0h9xZi7MwzuX1Ukwh3X22vqsX4YRbipIelSFtrDzleNVUm5jj0ow==
   dependencies:
-    "@lerna/child-process" "3.13.0"
+    "@lerna/child-process" "3.13.3"
     "@lerna/get-npm-exec-opts" "3.13.0"
     npmlog "^4.1.2"
 
@@ -782,17 +782,17 @@
     inquirer "^6.2.0"
     npmlog "^4.1.2"
 
-"@lerna/publish@3.13.2":
-  version "3.13.2"
-  resolved "https://registry.yarnpkg.com/@lerna/publish/-/publish-3.13.2.tgz#3afccceff5c06b3202d91baf917cd29ab4fb0163"
-  integrity sha512-L8iceC3Z2YJnlV3cGbfk47NSh1+iOo1tD65z+BU3IYLRpPnnSf8i6BORdKV8rECDj6kjLYvL7//2yxbHy7shhA==
+"@lerna/publish@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/publish/-/publish-3.13.3.tgz#9adde543064e85851f02c0c2dbd40d52d1c519a4"
+  integrity sha512-Ni3pZKueIfgJJoL0OXfbAuWhGlJrDNwGx3CYWp2dbNqJmKD6uBZmsDtmeARKDp92oUK60W0drXCMydkIFFHMDQ==
   dependencies:
     "@lerna/batch-packages" "3.13.0"
-    "@lerna/check-working-tree" "3.13.0"
-    "@lerna/child-process" "3.13.0"
-    "@lerna/collect-updates" "3.13.0"
-    "@lerna/command" "3.13.1"
-    "@lerna/describe-ref" "3.13.0"
+    "@lerna/check-working-tree" "3.13.3"
+    "@lerna/child-process" "3.13.3"
+    "@lerna/collect-updates" "3.13.3"
+    "@lerna/command" "3.13.3"
+    "@lerna/describe-ref" "3.13.3"
     "@lerna/log-packed" "3.13.0"
     "@lerna/npm-conf" "3.13.0"
     "@lerna/npm-dist-tag" "3.13.0"
@@ -804,7 +804,7 @@
     "@lerna/run-lifecycle" "3.13.0"
     "@lerna/run-parallel-batches" "3.13.0"
     "@lerna/validation-error" "3.13.0"
-    "@lerna/version" "3.13.2"
+    "@lerna/version" "3.13.3"
     figgy-pudding "^3.5.1"
     fs-extra "^7.0.0"
     libnpmaccess "^3.0.1"
@@ -834,12 +834,12 @@
     npmlog "^4.1.2"
     read-cmd-shim "^1.0.1"
 
-"@lerna/rimraf-dir@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/rimraf-dir/-/rimraf-dir-3.13.0.tgz#bb1006104b4aabcb6985624273254648f872b278"
-  integrity sha512-kte+pMemulre8cmPqljxIYjCmdLByz8DgHBHXB49kz2EiPf8JJ+hJFt0PzEubEyJZ2YE2EVAx5Tv5+NfGNUQyQ==
+"@lerna/rimraf-dir@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/rimraf-dir/-/rimraf-dir-3.13.3.tgz#3a8e71317fde853893ef0262bc9bba6a180b7227"
+  integrity sha512-d0T1Hxwu3gpYVv73ytSL+/Oy8JitsmvOYUR5ouRSABsmqS7ZZCh5t6FgVDDGVXeuhbw82+vuny1Og6Q0k4ilqw==
   dependencies:
-    "@lerna/child-process" "3.13.0"
+    "@lerna/child-process" "3.13.3"
     npmlog "^4.1.2"
     path-exists "^3.0.0"
     rimraf "^2.6.2"
@@ -862,15 +862,15 @@
     p-map "^1.2.0"
     p-map-series "^1.0.0"
 
-"@lerna/run@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/run/-/run-3.13.1.tgz#87e174c1d271894ddd29adc315c068fb7b1b0117"
-  integrity sha512-nv1oj7bsqppWm1M4ifN+/IIbVu9F4RixrbQD2okqDGYne4RQPAXyb5cEZuAzY/wyGTWWiVaZ1zpj5ogPWvH0bw==
+"@lerna/run@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/run/-/run-3.13.3.tgz#0781c82d225ef6e85e28d3e763f7fc090a376a21"
+  integrity sha512-ygnLIfIYS6YY1JHWOM4CsdZiY8kTYPsDFOLAwASlRnlAXF9HiMT08GFXLmMHIblZJ8yJhsM2+QgraCB0WdxzOQ==
   dependencies:
     "@lerna/batch-packages" "3.13.0"
-    "@lerna/command" "3.13.1"
-    "@lerna/filter-options" "3.13.0"
-    "@lerna/npm-run-script" "3.13.0"
+    "@lerna/command" "3.13.3"
+    "@lerna/filter-options" "3.13.3"
+    "@lerna/npm-run-script" "3.13.3"
     "@lerna/output" "3.13.0"
     "@lerna/run-parallel-batches" "3.13.0"
     "@lerna/timer" "3.13.0"
@@ -912,18 +912,18 @@
   dependencies:
     npmlog "^4.1.2"
 
-"@lerna/version@3.13.2":
-  version "3.13.2"
-  resolved "https://registry.yarnpkg.com/@lerna/version/-/version-3.13.2.tgz#cc177c32c6404ab9d4b7e3d6da90789d48f768b4"
-  integrity sha512-85AEn6Cx5p1VOejEd5fpTyeDCx6yejSJCgbILkx+gXhLhFg2XpFzLswMd+u71X7RAttWHvhzeKJAw4tWTXDvpQ==
+"@lerna/version@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/version/-/version-3.13.3.tgz#3ec1b5aee2fd42353b95452c38cc0b284b93a1f0"
+  integrity sha512-o/yQGAwDHmyu17wTj4Kat1/uDhjYFMeG+H0Y0HC4zJ4a/T6rEiXx7jJrnucPTmTQTDcUBoH/It5LrPYGOPsExA==
   dependencies:
     "@lerna/batch-packages" "3.13.0"
-    "@lerna/check-working-tree" "3.13.0"
-    "@lerna/child-process" "3.13.0"
-    "@lerna/collect-updates" "3.13.0"
-    "@lerna/command" "3.13.1"
+    "@lerna/check-working-tree" "3.13.3"
+    "@lerna/child-process" "3.13.3"
+    "@lerna/collect-updates" "3.13.3"
+    "@lerna/command" "3.13.3"
     "@lerna/conventional-commits" "3.13.0"
-    "@lerna/github-client" "3.13.1"
+    "@lerna/github-client" "3.13.3"
     "@lerna/output" "3.13.0"
     "@lerna/prompt" "3.13.0"
     "@lerna/run-lifecycle" "3.13.0"
@@ -989,9 +989,9 @@
     universal-user-agent "^2.0.1"
 
 "@octokit/rest@^16.16.0":
-  version "16.23.4"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.23.4.tgz#4d8bcb1cc0cf6eeb8865632d4d60d79fc3425bbf"
-  integrity sha512-fQuYQ0vgNLkzeN0KEsqN0aS6EPzcuaePT5M5cE5qnKayaxFwRIQOMhNR/rTmEqo/zDK/20ZAcHsgLKodSsJtww==
+  version "16.24.3"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.24.3.tgz#5f844be604826b352d9683a133839341db2bed23"
+  integrity sha512-fBr2ziN4WT9G9sYTfnNVI/0wCb68ZI5isNU48lfWXQDyAy4ftlrh0SkIbhL7aigXUjcY0cX5J46ypyRPH0/U0g==
   dependencies:
     "@octokit/request" "3.0.0"
     atob-lite "^2.0.0"
@@ -1036,9 +1036,9 @@
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
 "@types/node@*":
-  version "11.13.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.4.tgz#f83ec3c3e05b174b7241fadeb6688267fe5b22ca"
-  integrity sha512-+rabAZZ3Yn7tF/XPGHupKIL5EcAbrLxnTr/hgQICxbeuAfWtT0UZSfULE+ndusckBItcv4o6ZeOJplQikVcLvQ==
+  version "11.13.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.5.tgz#266564afa8a6a09dc778dfacc703ed3f09c80516"
+  integrity sha512-/OMMBnjVtDuwX1tg2pkYVSqRIDSmNTnvVvmvP/2xiMAAWf4a5+JozrApCrO4WCAILmXVxfNoQ3E+0HJbNpFVGg==
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
@@ -1663,6 +1663,14 @@ array-ify@^1.0.0:
   resolved "https://registry.yarnpkg.com/array-ify/-/array-ify-1.0.0.tgz#9e528762b4a9066ad163a6962a364418e9626ece"
   integrity sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=
 
+array-includes@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.0.3.tgz#184b48f62d92d7452bb31b323165c7f8bd02266d"
+  integrity sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.7.0"
+
 array-initial@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/array-initial/-/array-initial-1.1.0.tgz#2fa74b26739371c3947bd7a7adc73be334b3d795"
@@ -1783,9 +1791,9 @@ async-done@^1.2.0, async-done@^1.2.2:
     stream-exhaust "^1.0.1"
 
 async-each@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.2.tgz#8b8a7ca2a658f927e9f307d6d1a42f4199f0f735"
-  integrity sha512-6xrbvN0MOBKSJDdonmSSz2OwFSgxRaVtBDes26mj9KIGtDo+g9xosFRSC+i1gQh2oAN/tQ62AI/pGZGQjVOiRg==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
+  integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
 async-settle@^1.0.0:
   version "1.0.0"
@@ -2496,10 +2504,10 @@ cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
-cli-kit@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/cli-kit/-/cli-kit-0.10.0.tgz#b09c4906043d387319edc48a8acb96db1c95db80"
-  integrity sha512-gG/1leIc5FshC/sPuNBNmoTz7RYTDkoQPrzjh0D7SvNnVkb+vAgen0aG+0H+pmxJq+0dSg843eDBFbp7+S7LRw==
+cli-kit@^0.10.2:
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/cli-kit/-/cli-kit-0.10.2.tgz#49eef28c4f1d882fdb70976e3692dcc0e9e91236"
+  integrity sha512-965KvPNFXCun4OKqeBFtXjcOjV5RkG5n3+UH+tD2T1AUXW6cdUwjKRyWNgOJ840Zy8H+MvcGlly+2gR6lOkSkw==
   dependencies:
     argv-split "^2.0.1"
     fast-levenshtein "^2.0.6"
@@ -2693,9 +2701,9 @@ compare-func@^1.3.1:
     dot-prop "^3.0.0"
 
 component-emitter@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
-  integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
+  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -3060,7 +3068,7 @@ dateformat@^2.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-2.2.0.tgz#4065e2013cf9fb916ddfd82efb506ad4c6769062"
   integrity sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=
 
-dateformat@^3.0.0:
+dateformat@^3.0.0, dateformat@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
@@ -3498,7 +3506,7 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.5.1:
+es-abstract@^1.5.1, es-abstract@^1.7.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
   integrity sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==
@@ -3720,10 +3728,10 @@ eslint-import-resolver-node@^0.3.2:
     debug "^2.6.9"
     resolve "^1.5.0"
 
-eslint-module-utils@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz#546178dab5e046c8b562bbb50705e2456d7bda49"
-  integrity sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==
+eslint-module-utils@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz#8b93499e9b00eab80ccb6614e69f03678e84e09a"
+  integrity sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==
   dependencies:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
@@ -3739,20 +3747,21 @@ eslint-plugin-chai-friendly@^0.4.1:
   integrity sha512-hkpLN7VVoGGsofZjUhcQ+sufC3FgqMJwD0DvAcRfxY1tVRyQyVsqpaKnToPHJQOrRo0FQ0fSEDwW2gr4rsNdGA==
 
 eslint-plugin-import@^2.16.0:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.16.0.tgz#97ac3e75d0791c4fac0e15ef388510217be7f66f"
-  integrity sha512-z6oqWlf1x5GkHIFgrSvtmudnqM6Q60KM4KvpWi5ubonMjycLjndvd5+8VAZIsTlHC03djdgJuyKG6XO577px6A==
+  version "2.17.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.17.2.tgz#d227d5c6dc67eca71eb590d2bb62fb38d86e9fcb"
+  integrity sha512-m+cSVxM7oLsIpmwNn2WXTJoReOF9f/CtLMo7qOVmKd1KntBy0hEcuNZ3erTmWjx+DxRO0Zcrm5KwAvI9wHcV5g==
   dependencies:
+    array-includes "^3.0.3"
     contains-path "^0.1.0"
     debug "^2.6.9"
     doctrine "1.5.0"
     eslint-import-resolver-node "^0.3.2"
-    eslint-module-utils "^2.3.0"
+    eslint-module-utils "^2.4.0"
     has "^1.0.3"
     lodash "^4.17.11"
     minimatch "^3.0.4"
     read-pkg-up "^2.0.0"
-    resolve "^1.9.0"
+    resolve "^1.10.0"
 
 eslint-plugin-mocha@^5.3.0:
   version "5.3.0"
@@ -4107,6 +4116,11 @@ filename-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
   integrity sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=
 
+filesize@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-4.1.2.tgz#fcd570af1353cea97897be64f56183adb995994b"
+  integrity sha512-iSWteWtfNcrWQTkQw8ble2bnonSl7YJImsn9OZKpE2E4IHhXI78eASpDYUljXZZdYj36QsEKjOs/CsiDqmKMJw==
+
 fill-range@^2.1.0:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.4.tgz#eb1e773abb056dcd8df2bfdf6af59b8b3a936565"
@@ -4368,12 +4382,12 @@ fs.realpath@^1.0.0:
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
 fsevents@^1.2.7:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.7.tgz#4851b664a3783e52003b3c66eb0eee1074933aa4"
-  integrity sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.8.tgz#57ea5320f762cd4696e5e8e87120eccc8b11cacf"
+  integrity sha512-tPvHgPGB7m40CZ68xqFGkKuzN+RnpGmSV+hgeKxhRpbxdqKXUFJGC3yonBOLzQBcJyGpdZFDfCsdOC2KFsXzeA==
   dependencies:
-    nan "^2.9.2"
-    node-pre-gyp "^0.10.0"
+    nan "^2.12.1"
+    node-pre-gyp "^0.12.0"
 
 fstream@^1.0.0, fstream@^1.0.2:
   version "1.0.11"
@@ -4836,9 +4850,9 @@ gulplog@^1.0.0:
     glogg "^1.0.0"
 
 handlebars@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.1.tgz#6e4e41c18ebe7719ae4d38e5aca3d32fa3dd23d3"
-  integrity sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
+  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"
@@ -5184,9 +5198,9 @@ init-package-json@^1.10.3:
     validate-npm-package-name "^3.0.0"
 
 inquirer@^6.2.0, inquirer@^6.2.2:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.2.tgz#46941176f65c9eb20804627149b743a218f25406"
-  integrity sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.3.1.tgz#7a413b5e7950811013a3db491c61d1f3b776e8e7"
+  integrity sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==
   dependencies:
     ansi-escapes "^3.2.0"
     chalk "^2.4.2"
@@ -5199,7 +5213,7 @@ inquirer@^6.2.0, inquirer@^6.2.2:
     run-async "^2.2.0"
     rxjs "^6.4.0"
     string-width "^2.1.0"
-    strip-ansi "^5.0.0"
+    strip-ansi "^5.1.0"
     through "^2.3.6"
 
 interpret@^1.1.0:
@@ -5593,55 +5607,55 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
-istanbul-lib-coverage@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#0b891e5ad42312c2b9488554f603795f9a2211ba"
-  integrity sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==
+istanbul-lib-coverage@^2.0.3, istanbul-lib-coverage@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#927a354005d99dd43a24607bb8b33fd4e9aca1ad"
+  integrity sha512-LXTBICkMARVgo579kWDm8SqfB6nvSDKNqIOBEjmJRnL04JvoMHCYGWaMddQnseJYtkEuEvO/sIcOxPLk9gERug==
 
 istanbul-lib-hook@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-2.0.3.tgz#e0e581e461c611be5d0e5ef31c5f0109759916fb"
-  integrity sha512-CLmEqwEhuCYtGcpNVJjLV1DQyVnIqavMLFHV/DP+np/g3qvdxu3gsPqYoJMXm15sN84xOlckFB3VNvRbf5yEgA==
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-2.0.6.tgz#5baa6067860a38290aef038b389068b225b01b7d"
+  integrity sha512-829DKONApZ7UCiPXcOYWSgkFXa4+vNYoNOt3F+4uDJLKL1OotAoVwvThoEj1i8jmOj7odbYcR3rnaHu+QroaXg==
   dependencies:
     append-transform "^1.0.0"
 
 istanbul-lib-instrument@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz#a2b5484a7d445f1f311e93190813fa56dfb62971"
-  integrity sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-3.2.0.tgz#c549208da8a793f6622257a2da83e0ea96ae6a93"
+  integrity sha512-06IM3xShbNW4NgZv5AP4QH0oHqf1/ivFo8eFys0ZjPXHGldHJQWb3riYOKXqmOqfxXBfxu4B+g/iuhOPZH0RJg==
   dependencies:
     "@babel/generator" "^7.0.0"
     "@babel/parser" "^7.0.0"
     "@babel/template" "^7.0.0"
     "@babel/traverse" "^7.0.0"
     "@babel/types" "^7.0.0"
-    istanbul-lib-coverage "^2.0.3"
-    semver "^5.5.0"
+    istanbul-lib-coverage "^2.0.4"
+    semver "^6.0.0"
 
 istanbul-lib-report@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-2.0.4.tgz#bfd324ee0c04f59119cb4f07dab157d09f24d7e4"
-  integrity sha512-sOiLZLAWpA0+3b5w5/dq0cjm2rrNdAfHWaGhmn7XEFW6X++IV9Ohn+pnELAl9K3rfpaeBfbmH9JU5sejacdLeA==
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-2.0.7.tgz#370d80d433c4dbc7f58de63618f49599c74bd954"
+  integrity sha512-wLH6beJBFbRBLiTlMOBxmb85cnVM1Vyl36N48e4e/aTKSM3WbOx7zbVIH1SQ537fhhsPbX0/C5JB4qsmyRXXyA==
   dependencies:
-    istanbul-lib-coverage "^2.0.3"
-    make-dir "^1.3.0"
+    istanbul-lib-coverage "^2.0.4"
+    make-dir "^2.1.0"
     supports-color "^6.0.0"
 
 istanbul-lib-source-maps@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.2.tgz#f1e817229a9146e8424a28e5d69ba220fda34156"
-  integrity sha512-JX4v0CiKTGp9fZPmoxpu9YEkPbEqCqBbO3403VabKjH+NRXo72HafD5UgnjTEqHL2SAjaZK1XDuDOkn6I5QVfQ==
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.5.tgz#1d9ee9d94d2633f15611ee7aae28f9cac6d1aeb9"
+  integrity sha512-eDhZ7r6r1d1zQPVZehLc3D0K14vRba/eBYkz3rw16DLOrrTzve9RmnkcwrrkWVgO1FL3EK5knujVe5S8QHE9xw==
   dependencies:
     debug "^4.1.1"
-    istanbul-lib-coverage "^2.0.3"
-    make-dir "^1.3.0"
+    istanbul-lib-coverage "^2.0.4"
+    make-dir "^2.1.0"
     rimraf "^2.6.2"
     source-map "^0.6.1"
 
 istanbul-reports@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-2.1.1.tgz#72ef16b4ecb9a4a7bd0e2001e00f95d1eec8afa9"
-  integrity sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-2.2.3.tgz#14e0d00ecbfa9387757999cf36599b88e9f2176e"
+  integrity sha512-T6EbPuc8Cb620LWAYyZ4D8SSn06dY9i1+IgUX2lTH8gbwflMc9Obd33zHTyNX653ybjpamAHS9toKS3E6cGhTw==
   dependencies:
     handlebars "^4.1.0"
 
@@ -5868,26 +5882,26 @@ lead@^1.0.0:
   dependencies:
     flush-write-stream "^1.0.2"
 
-lerna@^3.13.2:
-  version "3.13.2"
-  resolved "https://registry.yarnpkg.com/lerna/-/lerna-3.13.2.tgz#68f25cce4219ef9e49d246f10d0f20c4f0bc1622"
-  integrity sha512-2iliiFVAMNqaKsVSJ90p49dur93d5RlktotAJNp+uuHsCuIIAvwceqmSgDQCmWu4GkgAom+5uy//KV6F9t8fLA==
+lerna@^3.13.3:
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/lerna/-/lerna-3.13.3.tgz#bfd64e99466eaaf35b5d27994973b9f694796181"
+  integrity sha512-0TkG40F02A4wjKraJBztPtj87BjUezFmaZKAha8eLdtngZkSpAdrSANa5K7jnnA8mywmpQwrKJuBmjdNpm9cBw==
   dependencies:
-    "@lerna/add" "3.13.1"
-    "@lerna/bootstrap" "3.13.1"
-    "@lerna/changed" "3.13.2"
-    "@lerna/clean" "3.13.1"
+    "@lerna/add" "3.13.3"
+    "@lerna/bootstrap" "3.13.3"
+    "@lerna/changed" "3.13.3"
+    "@lerna/clean" "3.13.3"
     "@lerna/cli" "3.13.0"
-    "@lerna/create" "3.13.1"
-    "@lerna/diff" "3.13.1"
-    "@lerna/exec" "3.13.1"
-    "@lerna/import" "3.13.1"
-    "@lerna/init" "3.13.1"
-    "@lerna/link" "3.13.1"
-    "@lerna/list" "3.13.1"
-    "@lerna/publish" "3.13.2"
-    "@lerna/run" "3.13.1"
-    "@lerna/version" "3.13.2"
+    "@lerna/create" "3.13.3"
+    "@lerna/diff" "3.13.3"
+    "@lerna/exec" "3.13.3"
+    "@lerna/import" "3.13.3"
+    "@lerna/init" "3.13.3"
+    "@lerna/link" "3.13.3"
+    "@lerna/list" "3.13.3"
+    "@lerna/publish" "3.13.3"
+    "@lerna/run" "3.13.3"
+    "@lerna/version" "3.13.3"
     import-local "^1.0.0"
     npmlog "^4.1.2"
 
@@ -6230,10 +6244,10 @@ lolex@^2.3.2:
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.5.tgz#113001d56bfc7e02d56e36291cc5c413d1aa0733"
   integrity sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==
 
-lolex@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-3.1.0.tgz#1a7feb2fefd75b3e3a7f79f0e110d9476e294434"
-  integrity sha512-zFo5MgCJ0rZ7gQg69S4pqBsLURbFw11X68C18OcJjJQbqaXm2NoTrGl1IMM3TIz0/BnN1tIs2tzmmqvCsOMMjw==
+lolex@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-4.0.1.tgz#4a99c2251579d693c6a083446dae0e5c3844d3fa"
+  integrity sha512-UHuOBZ5jjsKuzbB/gRNNW8Vg8f00Emgskdq2kvZxgBJCS0aqquAuXai/SkWORlKeZEiNQWZjFZOqIUcH9LqKCw==
 
 loose-envify@^1.0.0:
   version "1.4.0"
@@ -6284,7 +6298,7 @@ make-dir@^1.0.0, make-dir@^1.3.0:
   dependencies:
     pify "^3.0.0"
 
-make-dir@^2.0.0:
+make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
   integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==
@@ -6504,17 +6518,17 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@~1.38.0:
-  version "1.38.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.38.0.tgz#1a2aab16da9eb167b49c6e4df2d9c68d63d8e2ad"
-  integrity sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==
+mime-db@~1.39.0:
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.39.0.tgz#f95a20275742f7d2ad0429acfe40f4233543780e"
+  integrity sha512-DTsrw/iWVvwHH+9Otxccdyy0Tgiil6TWK/xhfARJZF/QFhwOgZgOIvA2/VIGpM8U7Q8z5nDmdDWC6tuVMJNibw==
 
 mime-types@^2.1.12, mime-types@~2.1.19:
-  version "2.1.22"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.22.tgz#fe6b355a190926ab7698c9a0556a11199b2199bd"
-  integrity sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==
+  version "2.1.23"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.23.tgz#d4eacd87de99348a6858fe1e479aad877388d977"
+  integrity sha512-ROk/m+gMVSrRxTkMlaQOvFmFmYDc7sZgrjjM76abqmd2Cc5fCV7jAMA5XUccEtJ3cYiYdgixUVI+fApc2LkXlw==
   dependencies:
-    mime-db "~1.38.0"
+    mime-db "~1.39.0"
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -6732,7 +6746,7 @@ mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nan@^2.11.1, nan@^2.9.2:
+nan@^2.11.1, nan@^2.12.1:
   version "2.13.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.2.tgz#f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7"
   integrity sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==
@@ -8356,7 +8370,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.9.0:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
   integrity sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==
@@ -8481,9 +8495,9 @@ semver@~5.5.0:
   integrity sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==
 
 serialize-javascript@^1.4.0:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.6.1.tgz#4d1f697ec49429a847ca6f442a2a755126c4d879"
-  integrity sha512-A5MOagrPFga4YaKQSWHryl7AXvbQkEqpw4NNYMTNYUNV51bA8ABHgYFpqKx+YFFrw59xMV1qGH1R4AgoNIVgCw==
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.7.0.tgz#d6e0dfb2a3832a8c94468e6eb1db97e55a192a65"
+  integrity sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
@@ -8555,15 +8569,15 @@ sinon-chai@^3.3.0:
   integrity sha512-r2JhDY7gbbmh5z3Q62pNbrjxZdOAjpsqW/8yxAZRSqLZqowmfGZPGUZPFf3UX36NLis0cv8VEM5IJh9HgkSOAA==
 
 sinon@^7.3.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.3.1.tgz#e8276522104e6c08d1cb52a907270b0e316655c4"
-  integrity sha512-eQKMaeWovtOtYe2xThEvaHmmxf870Di+bim10c3ZPrL5bZhLGtu8cz+rOBTFz0CwBV4Q/7dYwZiqZbGVLZ+vjQ==
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.3.2.tgz#82dba3a6d85f6d2181e1eca2c10d8657c2161f28"
+  integrity sha512-thErC1z64BeyGiPvF8aoSg0LEnptSaWE7YhdWWbWXgelOyThent7uKOnnEh9zBxDbKixtr5dEko+ws1sZMuFMA==
   dependencies:
     "@sinonjs/commons" "^1.4.0"
     "@sinonjs/formatio" "^3.2.1"
     "@sinonjs/samsam" "^3.3.1"
     diff "^3.5.0"
-    lolex "^3.1.0"
+    lolex "^4.0.1"
     nise "^1.4.10"
     supports-color "^5.5.0"
 
@@ -8937,7 +8951,7 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.0.0, strip-ansi@^5.1.0:
+strip-ansi@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
@@ -9059,9 +9073,9 @@ taffydb@2.7.3:
   integrity sha1-KtNxaWKUmPylvIQkMJbTzeDsOjQ=
 
 tapable@^1.0.0, tapable@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.1.tgz#4d297923c5a72a42360de2ab52dadfaaec00018e"
-  integrity sha512-9I2ydhj8Z9veORCw5PRm4u9uebCn0mcCa6scWoNcbZ6dAtoo2618u9UUzxgmsCOreJpqDDuv61LvwofW7hLcBA==
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
+  integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
 tar-stream@^2.0.1:
   version "2.0.1"
@@ -9145,14 +9159,14 @@ terser@^3.16.1:
     source-map-support "~0.5.10"
 
 test-exclude@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-5.1.0.tgz#6ba6b25179d2d38724824661323b73e03c0c1de1"
-  integrity sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-5.2.2.tgz#7322f8ab037b0b93ad2aab35fe9068baf997a4c4"
+  integrity sha512-N2pvaLpT8guUpb5Fe1GJlmvmzH3x+DAKmmyEQmFP792QcLYoGE1syxztSvPD1V8yPe6VrcCt6YGQVjSRjCASsA==
   dependencies:
-    arrify "^1.0.1"
+    glob "^7.1.3"
     minimatch "^3.0.4"
     read-pkg-up "^4.0.0"
-    require-main-filename "^1.0.1"
+    require-main-filename "^2.0.0"
 
 text-extensions@^1.0.0:
   version "1.9.0"
@@ -9703,9 +9717,9 @@ webpack-sources@^1.1.0, webpack-sources@^1.3.0:
     source-map "~0.6.1"
 
 webpack@^4.29.6:
-  version "4.29.6"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.29.6.tgz#66bf0ec8beee4d469f8b598d3988ff9d8d90e955"
-  integrity sha512-MwBwpiE1BQpMDkbnUUaW6K8RFZjljJHArC6tWQJoFm0oQtfoSebtg4Y7/QHnJ/SddtjYLHaKGX64CFjG5rehJw==
+  version "4.30.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.30.0.tgz#aca76ef75630a22c49fcc235b39b4c57591d33a9"
+  integrity sha512-4hgvO2YbAFUhyTdlR4FNyt2+YaYBYHavyzjCMbZzgglo02rlKi/pcsEzwCuCpsn1ryzIl1cq/u8ArIKu8JBYMg==
   dependencies:
     "@webassemblyjs/ast" "1.8.5"
     "@webassemblyjs/helper-module-context" "1.8.5"


### PR DESCRIPTION
BREAKING CHANGE(android): Renamed 'sdk' and 'ndk' to 'sdks' and 'ndks'.
BREAKING CHANGE(android): No longer scan for 'android' executable.
BREAKING CHANGE(android): Removed 'targets'. Combine 'addons' and 'platforms' to get same result.
fix(android): Fixed bug with selecting the correct default Android SDK.
BREAKING CHANGE(ios): Updated to latest ioslib which changes the iOS sim watch companion map.
BREAKING CHANGE(system info): Schema changes introduced by Android and iOS plugin schema changes.
feat(titanium): Added implementation for 'ti info' command.
chore: Updated to latest Lerna version.
chore: Updated npm deps.