### PR TITLE
Top-level housekeeping

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,4 @@
 {
-  "lerna": "3.13.2",
   "version": "independent",
   "npmClient": "yarn",
   "packages": [

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   },
   "scripts": {
     "build": "lerna exec gulp build",
-    "link": "lerna exec yarn link"
+    "link": "lerna exec yarn link",
+    "unlink": "lerna exec yarn unlink"
   },
   "workspaces": {
     "packages": [
@@ -15,6 +16,7 @@
     ]
   },
   "dependencies": {
-    "gulp": "^4.0.2"
+    "gulp": "^4.0.2",
+    "node-gyp": "^5.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6970,7 +6970,7 @@ node-forge@^0.8.2:
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.8.5.tgz#57906f07614dc72762c84cef442f427c0e1b86ee"
   integrity sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==
 
-node-gyp@^5.0.2:
+node-gyp@^5.0.2, node-gyp@^5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-5.0.3.tgz#80d64c23790244991b6d44532f0a351bedd3dd45"
   integrity sha512-z/JdtkFGUm0QaQUusvloyYuGDub3nUbOo5de1Fz57cM++osBTvQatBUSTlF1k/w8vFHPxxXW6zxGvkxXSpaBkQ==


### PR DESCRIPTION
chore: Added 'unlink' task.
chore: Removed lerna version from 'lerna.json'.
fix: Added node-gyp 5 so that winreglib can be compiled with VS2019.